### PR TITLE
Fix 3/4 speed fans

### DIFF
--- a/src/ST_DeviceCharacteristics.js
+++ b/src/ST_DeviceCharacteristics.js
@@ -273,7 +273,7 @@ module.exports = class DeviceCharacteristics {
             _accessory.manageGetSetCharacteristic(_service, _accessory, Characteristic.RotationSpeed, spdAttr, {
                 cmdHasVal: true,
                 props: {
-                    minSteps: spdSteps
+                    minStep: spdSteps
                 }
             });
         } else {


### PR DESCRIPTION
[Problem]
The Home app would allow a fan to be set to any value from 0-100%, despite a fan
being selected in the HomeBridge v2 SmartApp as a "3 speeds" or "4 speeds" fan.

[Solution]
The Characteristic.RotationSpeed was mistakenly having the "minSteps" property
set, when the actual property name is "minStep".

[Testing]
Restarted HomeBridge, and verified Home app only allows setting multiples of
33%.

issue tonesto7/homebridge-smartthings-v2#21

<!--- Provide a general summary of your changes in the Title above -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes

<!--- Describe your changes in detail -->

## Reason for Change

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
